### PR TITLE
Updated Virgin Mobile URL (complete fix now)

### DIFF
--- a/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/ReferenceScraper.java
+++ b/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/ReferenceScraper.java
@@ -62,7 +62,7 @@ public class ReferenceScraper implements IVMCScraper
     @Override
     public String getDateDue(final String str)
     {
-        String srch = "<h3>Date Due</h3><p>";
+        String srch = "<li id=\"charge_date\"><h3>You will be charged on</h3><p>";
         int start = str.indexOf(srch);
         int end = str.indexOf("</p>", start);
 

--- a/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/WebsiteScraper.java
+++ b/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/WebsiteScraper.java
@@ -35,7 +35,7 @@ public class WebsiteScraper {
             }
          };
 
-         String url = "https://www1.virginmobileusa.com/login/login.do";    
+         String url = "https://www2.virginmobileusa.com/login/login.do";    
          //String url = "https://www1.virginmobileusa.com/login/login.do";    
          //   String url = "https://www1.virginmobileusa.com/myaccount/home.do";
 

--- a/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/WebsiteScraper.java
+++ b/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/WebsiteScraper.java
@@ -59,11 +59,20 @@ public class WebsiteScraper {
 
          connection.setDoOutput(true);
 
+         String content = "loginRoutingInfo=&min=" + username + "&vkey=" + password + "&submit=submit";
+         
+         connection.setFixedLengthStreamingMode(content.length());
+         connection.setRequestProperty("Host", "www2.virginmobileusa.com");
+         connection.setRequestProperty("Accept-Language", "en-US,en;q=0.9");
+         
+         
+         
+         
          // try {
          //Thread.sleep(5000);
          OutputStreamWriter out = new OutputStreamWriter(
                connection.getOutputStream());
-         out.write("loginRoutingInfo=&min=" + username + "&vkey=" + password + "&submit=submit");
+         out.write(content);
          out.close();
          //} catch (IOException e) {
          //   e.printStackTrace();

--- a/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/WebsiteScraper.java
+++ b/VirginMobileMinutesChecker/src/com/jaygoel/virginminuteschecker/WebsiteScraper.java
@@ -192,7 +192,7 @@ public class WebsiteScraper {
          rc.put("Charge Deducted", line.substring(start + srch.length(), end));
       }
 
-      srch = "<h3>You will be charged on</h3><p>";
+      srch = "<li id=\"charge_date\"><h3>You will be charged on</h3><p>";
       start = line.indexOf(srch);
       end = line.indexOf("</p>", start);
 


### PR DESCRIPTION
I updated the virgin mobile URL. It required the ww2 instead of ww1.
(This is also true if logging in via a web broswer).

While running in the emulator it was not able to correctly pull the
charge date nor did it show the black line in the pie graph. <del>I don't
know if this was somethign with my emulator, or</del> something that will need
fixed.  (see update below)
